### PR TITLE
Updated destination for 'Join Us' in navigation bar

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -5,6 +5,6 @@ links:
   - title: What We Do
     url: /what-we-do
   - title: Join Us
-    url: /join-us
+    url: /join-us/
   - title: Reach Us
     collection: reach-us

--- a/pages/Join Us.md
+++ b/pages/Join Us.md
@@ -2,6 +2,7 @@
 title: Join Us
 permalink: /join-us/
 description: ""
+variant: markdown
 ---
 <style>
 .triple-column-div {


### PR DESCRIPTION
Connection was broken. 'Join Us' was bounced back to landing page. Updated destination for 'Join Us' in navigation bar.